### PR TITLE
Add Expo product CRUD with Redux logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ This project demonstrates a simple CRUD application using React, Redux and Tailw
 Run `npm install` to install dependencies before starting the app.
 
 Type definitions are provided by `@types/react` and `@types/react-dom`.
+
+## Expo Usage
+
+This project includes an Expo setup with a Firebase placeholder and Product CRUD
+features. Install dependencies and start the app with:
+
+```
+npm install
+npx expo start
+```
+
+The Expo CLI lets you preview the app on iOS, Android or the web.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "expo": {
+    "name": "react-redux-shadcn-crud",
+    "slug": "react-redux-shadcn-crud",
+    "platforms": ["ios", "android", "web"],
+    "version": "1.0.0",
+    "sdkVersion": "50.0.0",
+    "orientation": "portrait",
+    "web": { "bundler": "metro" }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.5.2",
         "typescript": "^5.8.3",
-        "@vitejs/plugin-react": "^4.5.2",
         "vite": "^6.3.5"
       }
     },
@@ -1127,6 +1126,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
+      "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -1213,6 +1232,13 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1616,6 +1642,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,9 @@
-import PostList from './components/PostList';
+import ProductPage from './components/ProductPage';
 
 export default function App() {
   return (
-    <div className="container mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">Posts CRUD</h1>
-      <PostList />
-    </div>
+    <>
+      <ProductPage />
+    </>
   );
 }

--- a/src/components/PageComponent.tsx
+++ b/src/components/PageComponent.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react';
+
+export default function PageComponent({ children }: { children: ReactNode }) {
+  return <div className="container mx-auto p-4">{children}</div>;
+}

--- a/src/components/ProductForm.tsx
+++ b/src/components/ProductForm.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect, FormEvent } from 'react';
+import { useProductActions } from '../context/ProductContext';
+import type { Product } from '../types';
+
+interface Props {
+  current: Product | null;
+}
+
+export default function ProductForm({ current }: Props) {
+  const { createProduct, editProduct } = useProductActions();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [price, setPrice] = useState('');
+
+  useEffect(() => {
+    if (current) {
+      setTitle(current.title);
+      setDescription(current.description);
+      setPrice(String(current.price));
+    } else {
+      setTitle('');
+      setDescription('');
+      setPrice('');
+    }
+  }, [current]);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const product = { title, description, price: Number(price), id: current?.id } as Product;
+    if (current) {
+      editProduct(product);
+    } else {
+      createProduct({ title, description, price: Number(price) });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 p-4 bg-white rounded shadow">
+      <input className="w-full border p-2 rounded" placeholder="Title" value={title} onChange={(e) => setTitle(e.target.value)} />
+      <input className="w-full border p-2 rounded" placeholder="Description" value={description} onChange={(e) => setDescription(e.target.value)} />
+      <input className="w-full border p-2 rounded" placeholder="Price" type="number" value={price} onChange={(e) => setPrice(e.target.value)} />
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+        {current ? 'Update' : 'Add'} Product
+      </button>
+    </form>
+  );
+}

--- a/src/components/ProductItem.tsx
+++ b/src/components/ProductItem.tsx
@@ -1,0 +1,27 @@
+import { useProductActions } from '../context/ProductContext';
+import type { Product } from '../types';
+
+interface Props {
+  product: Product;
+  onSelect: (product: Product) => void;
+}
+
+export default function ProductItem({ product, onSelect }: Props) {
+  const { removeProduct } = useProductActions();
+
+  return (
+    <div className="p-4 bg-white shadow rounded space-y-2">
+      <h2 className="text-lg font-semibold">{product.title}</h2>
+      <p>{product.description}</p>
+      <p className="text-sm text-gray-700">${product.price}</p>
+      <div className="flex gap-2">
+        <button onClick={() => onSelect(product)} className="px-2 py-1 bg-yellow-500 text-white rounded hover:bg-yellow-600">
+          Edit
+        </button>
+        <button onClick={() => removeProduct(product.id)} className="px-2 py-1 bg-red-600 text-white rounded hover:bg-red-700">
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -1,0 +1,52 @@
+import { useSelector } from 'react-redux';
+import { useEffect, useState } from 'react';
+import ProductItem from './ProductItem';
+import ProductForm from './ProductForm';
+import { useProductActions } from '../context/ProductContext';
+import {
+  selectProducts,
+  selectProductLoading,
+  selectProductError,
+} from '../store/selectors/productsSelectors';
+import type { Product } from '../types';
+
+export default function ProductList() {
+  const { fetchProducts } = useProductActions();
+  const products = useSelector(selectProducts);
+  const loading = useSelector(selectProductLoading);
+  const error = useSelector(selectProductError);
+  const [selected, setSelected] = useState<Product | null>(null);
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState('title');
+
+  useEffect(() => {
+    fetchProducts();
+  }, [fetchProducts]);
+
+  const filtered = products
+    .filter((p) => p.title.toLowerCase().includes(search.toLowerCase()))
+    .sort((a, b) => {
+      if (sort === 'price') {
+        return a.price - b.price;
+      }
+      return a.title.localeCompare(b.title);
+    });
+
+  return (
+    <div className="space-y-4">
+      <ProductForm current={selected} />
+      <div className="flex gap-2">
+        <input className="border p-2 rounded" placeholder="Search" value={search} onChange={(e) => setSearch(e.target.value)} />
+        <select className="border p-2 rounded" value={sort} onChange={(e) => setSort(e.target.value)}>
+          <option value="title">Title</option>
+          <option value="price">Price</option>
+        </select>
+      </div>
+      {loading && <p>Loading...</p>}
+      {error && <p className="text-red-600">{error}</p>}
+      {filtered.map((product) => (
+        <ProductItem key={product.id} product={product} onSelect={setSelected} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ProductPage.tsx
+++ b/src/components/ProductPage.tsx
@@ -1,0 +1,11 @@
+import PageComponent from './PageComponent';
+import ProductList from './ProductList';
+
+export default function ProductPage() {
+  return (
+    <PageComponent>
+      <h1 className="text-2xl font-bold mb-4">Products CRUD</h1>
+      <ProductList />
+    </PageComponent>
+  );
+}

--- a/src/context/ProductContext.tsx
+++ b/src/context/ProductContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext } from 'react';
+import { useDispatch } from 'react-redux';
+import type { ReactNode } from 'react';
+import {
+  fetchProducts,
+  createProduct,
+  editProduct,
+  removeProduct,
+} from '../store/effects/productsEffects';
+import type { Product } from '../types';
+import type { AppDispatch } from '../store/store';
+
+interface ProductActions {
+  fetchProducts: () => void;
+  createProduct: (p: Omit<Product, 'id'>) => void;
+  editProduct: (p: Product) => void;
+  removeProduct: (id: number) => void;
+}
+
+const ProductContext = createContext<ProductActions>({
+  fetchProducts: () => {},
+  createProduct: () => {},
+  editProduct: () => {},
+  removeProduct: () => {},
+});
+
+export const useProductActions = () => useContext(ProductContext);
+
+export function ProductProvider({ children }: { children: ReactNode }) {
+  const dispatch = useDispatch<AppDispatch>();
+
+  const actions: ProductActions = {
+    fetchProducts: () => dispatch(fetchProducts()),
+    createProduct: (p) => dispatch(createProduct(p)),
+    editProduct: (p) => dispatch(editProduct(p)),
+    removeProduct: (id) => dispatch(removeProduct(id)),
+  };
+
+  return (
+    <ProductContext.Provider value={actions}>{children}</ProductContext.Provider>
+  );
+}

--- a/src/data/products.json
+++ b/src/data/products.json
@@ -1,0 +1,7 @@
+[
+  { "id": 1, "title": "Phone", "description": "Smartphone", "price": 699 },
+  { "id": 2, "title": "Laptop", "description": "Notebook computer", "price": 1299 },
+  { "id": 3, "title": "Headphones", "description": "Noise cancelling", "price": 199 },
+  { "id": 4, "title": "Camera", "description": "Digital camera", "price": 499 },
+  { "id": 5, "title": "Watch", "description": "Smart watch", "price": 299 }
+]

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,0 +1,13 @@
+// Firebase initialization placeholder
+import { initializeApp } from 'firebase/app';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+};
+
+export const firebaseApp = initializeApp(firebaseConfig);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import App from './App';
 import store from './store/store';
+import { ProductProvider } from './context/ProductContext';
 
 const container = document.getElementById('root') as HTMLElement;
 const root: Root = createRoot(container);
@@ -10,7 +11,9 @@ const root: Root = createRoot(container);
 root.render(
   <StrictMode>
     <Provider store={store}>
-      <App />
+      <ProductProvider>
+        <App />
+      </ProductProvider>
     </Provider>
   </StrictMode>
 );

--- a/src/services/EntityService.ts
+++ b/src/services/EntityService.ts
@@ -1,0 +1,23 @@
+export default class EntityService<T extends { id: number }> {
+  protected baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
+
+  async getAll(): Promise<T[]> {
+    throw new Error('Method not implemented');
+  }
+
+  async create(data: Omit<T, 'id'>): Promise<T> {
+    throw new Error('Method not implemented');
+  }
+
+  async update(id: number, data: T): Promise<T> {
+    throw new Error('Method not implemented');
+  }
+
+  async delete(id: number): Promise<void> {
+    throw new Error('Method not implemented');
+  }
+}

--- a/src/services/ExpoHttpService.ts
+++ b/src/services/ExpoHttpService.ts
@@ -1,0 +1,35 @@
+import EntityService from './EntityService';
+
+export default class ExpoHttpService<T extends { id: number }> extends EntityService<T> {
+  protected async request(url: string, options?: RequestInit) {
+    const res = await fetch(url, options);
+    if (!res.ok) {
+      throw new Error(res.statusText);
+    }
+    return res.json();
+  }
+
+  async getAll(): Promise<T[]> {
+    return this.request(this.baseUrl);
+  }
+
+  async create(data: Omit<T, 'id'>): Promise<T> {
+    return this.request(this.baseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+  }
+
+  async update(id: number, data: T): Promise<T> {
+    return this.request(`${this.baseUrl}/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.request(`${this.baseUrl}/${id}`, { method: 'DELETE' });
+  }
+}

--- a/src/services/ProductMockProvider.ts
+++ b/src/services/ProductMockProvider.ts
@@ -1,0 +1,25 @@
+import products from '../data/products.json';
+import type { Product } from '../types';
+
+let data: Product[] = products as Product[];
+
+export default class ProductMockProvider {
+  async getAll(): Promise<Product[]> {
+    return [...data];
+  }
+
+  async create(product: Omit<Product, 'id'>): Promise<Product> {
+    const newProduct: Product = { ...product, id: Date.now() } as Product;
+    data = [newProduct, ...data];
+    return newProduct;
+  }
+
+  async update(id: number, product: Product): Promise<Product> {
+    data = data.map((p) => (p.id === id ? product : p));
+    return product;
+  }
+
+  async delete(id: number): Promise<void> {
+    data = data.filter((p) => p.id !== id);
+  }
+}

--- a/src/services/ProductService.ts
+++ b/src/services/ProductService.ts
@@ -1,0 +1,27 @@
+import ExpoHttpService from './ExpoHttpService';
+import ProductMockProvider from './ProductMockProvider';
+import type { Product } from '../types';
+
+const provider = new ProductMockProvider();
+
+export default class ProductService extends ExpoHttpService<Product> {
+  constructor() {
+    super('https://jsonplaceholder.typicode.com/products');
+  }
+
+  async getAll() {
+    return provider.getAll();
+  }
+
+  async create(data: Omit<Product, 'id'>) {
+    return provider.create(data);
+  }
+
+  async update(id: number, product: Product) {
+    return provider.update(id, product);
+  }
+
+  async delete(id: number) {
+    return provider.delete(id);
+  }
+}

--- a/src/store/actions/productsActions.ts
+++ b/src/store/actions/productsActions.ts
@@ -1,0 +1,15 @@
+import type { Product } from '../../types';
+
+export const SET_PRODUCTS = 'SET_PRODUCTS' as const;
+export const ADD_PRODUCT = 'ADD_PRODUCT' as const;
+export const UPDATE_PRODUCT = 'UPDATE_PRODUCT' as const;
+export const DELETE_PRODUCT = 'DELETE_PRODUCT' as const;
+export const SET_PRODUCT_LOADING = 'SET_PRODUCT_LOADING' as const;
+export const SET_PRODUCT_ERROR = 'SET_PRODUCT_ERROR' as const;
+
+export const setProducts = (products: Product[]) => ({ type: SET_PRODUCTS, payload: products });
+export const addProduct = (product: Product) => ({ type: ADD_PRODUCT, payload: product });
+export const updateProduct = (product: Product) => ({ type: UPDATE_PRODUCT, payload: product });
+export const deleteProduct = (id: number) => ({ type: DELETE_PRODUCT, payload: id });
+export const setProductLoading = (loading: boolean) => ({ type: SET_PRODUCT_LOADING, payload: loading });
+export const setProductError = (error: string) => ({ type: SET_PRODUCT_ERROR, payload: error });

--- a/src/store/effects/productsEffects.ts
+++ b/src/store/effects/productsEffects.ts
@@ -1,0 +1,61 @@
+import type { Dispatch } from 'redux';
+import ProductService from '../../services/ProductService';
+import {
+  setProducts,
+  addProduct,
+  updateProduct,
+  deleteProduct,
+  setProductLoading,
+  setProductError,
+} from '../actions/productsActions';
+import type { Product } from '../../types';
+
+const service = new ProductService();
+
+export const fetchProducts = () => async (dispatch: Dispatch) => {
+  dispatch(setProductLoading(true));
+  try {
+    const data = await service.getAll();
+    dispatch(setProducts(data));
+  } catch (err) {
+    dispatch(setProductError(String(err)));
+  } finally {
+    dispatch(setProductLoading(false));
+  }
+};
+
+export const createProduct = (product: Omit<Product, 'id'>) => async (dispatch: Dispatch) => {
+  dispatch(setProductLoading(true));
+  try {
+    const data = await service.create(product);
+    dispatch(addProduct(data));
+  } catch (err) {
+    dispatch(setProductError(String(err)));
+  } finally {
+    dispatch(setProductLoading(false));
+  }
+};
+
+export const editProduct = (product: Product) => async (dispatch: Dispatch) => {
+  dispatch(setProductLoading(true));
+  try {
+    await service.update(product.id, product);
+    dispatch(updateProduct(product));
+  } catch (err) {
+    dispatch(setProductError(String(err)));
+  } finally {
+    dispatch(setProductLoading(false));
+  }
+};
+
+export const removeProduct = (id: number) => async (dispatch: Dispatch) => {
+  dispatch(setProductLoading(true));
+  try {
+    await service.delete(id);
+    dispatch(deleteProduct(id));
+  } catch (err) {
+    dispatch(setProductError(String(err)));
+  } finally {
+    dispatch(setProductLoading(false));
+  }
+};

--- a/src/store/logDataMiddleware.ts
+++ b/src/store/logDataMiddleware.ts
@@ -1,0 +1,7 @@
+const logDataAction = () => (next: any) => (action: any) => {
+  const copy = JSON.parse(JSON.stringify(action));
+  console.log('LogDataAction:', copy);
+  return next(action);
+};
+
+export default logDataAction;

--- a/src/store/reducers/productsReducer.ts
+++ b/src/store/reducers/productsReducer.ts
@@ -1,0 +1,46 @@
+import {
+  SET_PRODUCTS,
+  ADD_PRODUCT,
+  UPDATE_PRODUCT,
+  DELETE_PRODUCT,
+  SET_PRODUCT_LOADING,
+  SET_PRODUCT_ERROR,
+} from '../actions/productsActions';
+import type { Product } from '../../types';
+
+interface ProductsState {
+  items: Product[];
+  loading: boolean;
+  error: string | null;
+}
+
+const initialState: ProductsState = {
+  items: [],
+  loading: false,
+  error: null,
+};
+
+export default function productsReducer(
+  state: ProductsState = initialState,
+  action: any
+): ProductsState {
+  switch (action.type) {
+    case SET_PRODUCT_LOADING:
+      return { ...state, loading: action.payload };
+    case SET_PRODUCT_ERROR:
+      return { ...state, error: action.payload };
+    case SET_PRODUCTS:
+      return { ...state, items: action.payload };
+    case ADD_PRODUCT:
+      return { ...state, items: [action.payload, ...state.items] };
+    case UPDATE_PRODUCT:
+      return {
+        ...state,
+        items: state.items.map((p) => (p.id === action.payload.id ? action.payload : p)),
+      };
+    case DELETE_PRODUCT:
+      return { ...state, items: state.items.filter((p) => p.id !== action.payload) };
+    default:
+      return state;
+  }
+}

--- a/src/store/selectors/productsSelectors.ts
+++ b/src/store/selectors/productsSelectors.ts
@@ -1,0 +1,5 @@
+import type { RootState } from '../store';
+
+export const selectProducts = (state: RootState) => state.products.items;
+export const selectProductLoading = (state: RootState) => state.products.loading;
+export const selectProductError = (state: RootState) => state.products.error;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,12 +1,15 @@
 import { createStore, applyMiddleware, combineReducers } from 'redux';
 import { thunk } from 'redux-thunk';
 import postsReducer from './reducers/postsReducer';
+import productsReducer from './reducers/productsReducer';
+import logDataAction from './logDataMiddleware';
 
 const rootReducer = combineReducers({
   posts: postsReducer,
+  products: productsReducer,
 });
 
-const store = createStore(rootReducer, applyMiddleware(thunk));
+const store = createStore(rootReducer, applyMiddleware(thunk, logDataAction()));
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,3 +3,11 @@ export interface Post {
   title: string;
   body: string;
 }
+
+export interface Product {
+  id: number;
+  title: string;
+  description: string;
+  price: number;
+}
+


### PR DESCRIPTION
## Summary
- add expo app configuration and firebase setup placeholder
- implement generic EntityService and ExpoHttpService
- create ProductService with mock provider
- add product Redux slice and middleware to log actions
- build Product CRUD page with filtering and sorting
- wrap app with ProductProvider context

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68818838fd88832d86ed14252e39c2b9