### PR TITLE
Add Expo todo app using Redux and Firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ This project demonstrates a simple CRUD application using React, Redux and Tailw
 Run `npm install` to install dependencies before starting the app.
 
 Type definitions are provided by `@types/react` and `@types/react-dom`.
+
+## Expo Todo App
+
+A simple React Native todo application built with Expo, Redux and Firebase lives in the `expo-todo` folder. To run the mobile app install dependencies using `npm install` inside that directory and then run `npm start`.

--- a/expo-todo/App.js
+++ b/expo-todo/App.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { SafeAreaView, StyleSheet } from 'react-native';
+import store from './store';
+import TodoInput from './components/TodoInput';
+import TodoList from './components/TodoList';
+
+export default function App() {
+  return (
+    <Provider store={store}>
+      <SafeAreaView style={styles.container}>
+        <TodoInput />
+        <TodoList />
+      </SafeAreaView>
+    </Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+});

--- a/expo-todo/components/TodoInput.js
+++ b/expo-todo/components/TodoInput.js
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { useDispatch } from 'react-redux';
+import { addTodo } from '../store/actions';
+
+export default function TodoInput() {
+  const [text, setText] = useState('');
+  const dispatch = useDispatch();
+
+  const submit = () => {
+    if (!text.trim()) return;
+    dispatch(addTodo(text));
+    setText('');
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        style={styles.input}
+        value={text}
+        onChangeText={setText}
+        placeholder="Add todo"
+      />
+      <Button title="Add" onPress={submit} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    marginVertical: 8,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    marginRight: 8,
+    padding: 8,
+  },
+});

--- a/expo-todo/components/TodoItem.js
+++ b/expo-todo/components/TodoItem.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { useDispatch } from 'react-redux';
+import { removeTodo } from '../store/actions';
+
+export default function TodoItem({ item }) {
+  const dispatch = useDispatch();
+  return (
+    <View style={styles.item}>
+      <Text style={styles.text}>{item.text}</Text>
+      <Button title="Done" onPress={() => dispatch(removeTodo(item.id))} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  item: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    padding: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+  },
+  text: {
+    flex: 1,
+  },
+});

--- a/expo-todo/components/TodoList.js
+++ b/expo-todo/components/TodoList.js
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+import { FlatList } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchTodos } from '../store/actions';
+import TodoItem from './TodoItem';
+
+export default function TodoList() {
+  const dispatch = useDispatch();
+  const todos = useSelector(state => state.todos);
+
+  useEffect(() => {
+    dispatch(fetchTodos());
+  }, [dispatch]);
+
+  return (
+    <FlatList
+      data={todos}
+      keyExtractor={item => item.id}
+      renderItem={({ item }) => <TodoItem item={item} />}
+    />
+  );
+}

--- a/expo-todo/firebase.js
+++ b/expo-todo/firebase.js
@@ -1,0 +1,16 @@
+// Firebase configuration and initialization
+// Replace with your actual Firebase project settings
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);

--- a/expo-todo/package.json
+++ b/expo-todo/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "expo-todo",
+  "version": "0.1.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "^18.0.0",
+    "react-native": "^0.73.0",
+    "firebase": "^10.12.0",
+    "react-redux": "^9.2.0",
+    "redux": "^5.0.1",
+    "redux-thunk": "^3.1.0"
+  }
+}

--- a/expo-todo/store/actions.js
+++ b/expo-todo/store/actions.js
@@ -1,0 +1,21 @@
+import { collection, addDoc, getDocs, deleteDoc, doc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export const SET_TODOS = 'SET_TODOS';
+
+export const fetchTodos = () => async dispatch => {
+  const snapshot = await getDocs(collection(db, 'todos'));
+  const todos = snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+  dispatch({ type: SET_TODOS, payload: todos });
+};
+
+export const addTodo = text => async dispatch => {
+  const docRef = await addDoc(collection(db, 'todos'), { text });
+  dispatch(fetchTodos());
+  return docRef.id;
+};
+
+export const removeTodo = id => async dispatch => {
+  await deleteDoc(doc(db, 'todos', id));
+  dispatch(fetchTodos());
+};

--- a/expo-todo/store/index.js
+++ b/expo-todo/store/index.js
@@ -1,0 +1,6 @@
+import { createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import reducer from './reducers';
+
+const store = createStore(reducer, applyMiddleware(thunk));
+export default store;

--- a/expo-todo/store/reducers.js
+++ b/expo-todo/store/reducers.js
@@ -1,0 +1,14 @@
+import { SET_TODOS } from './actions';
+
+const initialState = {
+  todos: [],
+};
+
+export default function reducer(state = initialState, action) {
+  switch (action.type) {
+    case SET_TODOS:
+      return { ...state, todos: action.payload };
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
## Summary
- add new Expo project under `expo-todo`
- set up Redux store and Firebase connection
- create basic todo components
- document how to run the mobile app

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688185b7d990832d9c0737b464ef15a9